### PR TITLE
Allow adminToken picture to be null

### DIFF
--- a/firebase-auth-provider/src/main/kotlin/com/kborowy/authprovider/firebase/FirebaseToken.kt
+++ b/firebase-auth-provider/src/main/kotlin/com/kborowy/authprovider/firebase/FirebaseToken.kt
@@ -8,7 +8,7 @@ data class FirebaseToken(
     val uid: String,
     val issuer: String,
     val name: String,
-    val picture: String,
+    val picture: String?,
     val email: String,
     val claims: Map<String, Any>?,
     val isEmailVerified: Boolean


### PR DESCRIPTION
 **Bug:**
 - If user has not picture on profile adminToken gets null pointer when deserialize
 
 **Solution:**
 - Allow adminToken picture to be null