### PR TITLE
adds input stream support for Admin file

### DIFF
--- a/firebase-auth-provider/src/main/kotlin/com/kborowy/authprovider/firebase/FirebaseAdminUtils.kt
+++ b/firebase-auth-provider/src/main/kotlin/com/kborowy/authprovider/firebase/FirebaseAdminUtils.kt
@@ -7,13 +7,17 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseAuthException
 import org.slf4j.LoggerFactory
 import java.io.File
+import java.io.InputStream
 
-internal class FirebaseAdminUtils(adminFile: File) {
+internal class FirebaseAdminUtils(adminFileStream: InputStream) {
+
+    constructor(adminFile: File) : this(adminFile.inputStream())
+
     private val logger = LoggerFactory.getLogger("FirebaseAdmin")
 
     private val firebaseOptions: FirebaseOptions by lazy {
         FirebaseOptions.builder().run {
-            val credentials = GoogleCredentials.fromStream(adminFile.inputStream())
+            val credentials = GoogleCredentials.fromStream(adminFileStream)
             setCredentials(credentials)
             build()
         }

--- a/firebase-auth-provider/src/main/kotlin/com/kborowy/authprovider/firebase/FirebaseAuthConfig.kt
+++ b/firebase-auth-provider/src/main/kotlin/com/kborowy/authprovider/firebase/FirebaseAuthConfig.kt
@@ -3,6 +3,7 @@ package com.kborowy.authprovider.firebase
 import io.ktor.server.auth.AuthenticationFunction
 import io.ktor.server.auth.AuthenticationProvider
 import java.io.File
+import java.io.InputStream
 
 
 class FirebaseAuthConfig(name: String?) : AuthenticationProvider.Config(name) {
@@ -15,6 +16,13 @@ class FirebaseAuthConfig(name: String?) : AuthenticationProvider.Config(name) {
   var adminFile: File = File("")
     set(f) {
       if (!::utils.isInitialized) {
+        utils = FirebaseAdminUtils(f)
+      }
+    }
+
+  var adminInputStream: InputStream? = null
+    set(f) {
+      if (!::utils.isInitialized && f != null) {
         utils = FirebaseAdminUtils(f)
       }
     }

--- a/sample/server/src/main/kotlin/com/samples/Application.kt
+++ b/sample/server/src/main/kotlin/com/samples/Application.kt
@@ -32,14 +32,11 @@ fun Application.module() {
     }
 
 
-    val firebaseAdminFile = File(
-        Thread.currentThread().contextClassLoader.getResource("admin.json")?.file
-            ?: throw Exception("admin.json file not found in resources")
-    )
+    val firebaseAdminResource = Thread.currentThread().contextClassLoader.getResourceAsStream("admin.json")
 
     install(Authentication) {
         firebase("my-auth") {
-            adminFile = firebaseAdminFile
+            adminInputStream = firebaseAdminResource
             realm = "Sample Server"
 
             validate { token ->


### PR DESCRIPTION
### Why?
I got the below exception when trying to load the resource as a file in Railway. I thought having the support to pass the admin file either as a resource or as a file could be good.
```
Exception class java.io.FileNotFoundException: file:/app/build/install/dev.rivu.xyz-shadow/lib/dev.rivu.xyz-all.jar!/adminsdk.json
```

It worked for me after adding this change.